### PR TITLE
Cleaned up some of the strined source code into its own files.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,40 +75,9 @@ fn tokenize(input: &str) -> Vec<Token> {
     tokens
 }
 
-const PREFACE_FORMER: &'static str = "#![allow(unused_imports)]
-#![allow(dead_code)]
-
-use std::io::{stdout, stdin, Read, Write};
-
-";
-
-const PREFACE_LATTER: &'static str = "fn ptr_wrap_add(ptr: &mut usize) {
-    if *ptr == TAPE_SIZE - 1 {
-        *ptr = 0;
-    } else {
-        *ptr += 1;
-    }
-}
-
-fn ptr_wrap_sub(ptr: &mut usize) {
-    if *ptr == 0 {
-        *ptr = TAPE_SIZE - 1;
-    } else {
-        *ptr -= 1;
-    }
-}
-
-fn main() {
-    let mut tape = [0u8; TAPE_SIZE];
-    let mut ptr = 0usize;
-
-    let stdout = stdout();
-    let mut handle = stdout.lock();
-
-";
-
-static SOURCE_END: &'static str = "}
-";
+const PREFACE_FORMER: &'static str = include_str!("preface_former.rs");
+const PREFACE_LATTER: &'static str = include_str!("preface_latter.rs");
+const SOURCE_END: &'static str = "}\n";
 
 fn compile(tokens: &[Token], out_file: Option<String>, tape_size: usize) {
     // Insert the preface, which in this instance, is just boiler-plate code

--- a/src/preface_former.rs
+++ b/src/preface_former.rs
@@ -1,0 +1,4 @@
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use std::io::{stdout, stdin, Read, Write};

--- a/src/preface_latter.rs
+++ b/src/preface_latter.rs
@@ -1,0 +1,24 @@
+fn ptr_wrap_add(ptr: &mut usize) {
+    if *ptr == TAPE_SIZE - 1 {
+        *ptr = 0;
+    } else {
+        *ptr += 1;
+    }
+}
+
+fn ptr_wrap_sub(ptr: &mut usize) {
+    if *ptr == 0 {
+        *ptr = TAPE_SIZE - 1;
+    } else {
+        *ptr -= 1;
+    }
+}
+
+fn main() {
+    let mut tape = [0u8; TAPE_SIZE];
+    let mut ptr = 0usize;
+
+    let stdout = stdout();
+    let mut handle = stdout.lock();
+
+// Intentionally no close brace here, there aren't normal source files.

--- a/src/preface_latter.rs
+++ b/src/preface_latter.rs
@@ -1,3 +1,5 @@
+
+#[inline]
 fn ptr_wrap_add(ptr: &mut usize) {
     if *ptr == TAPE_SIZE - 1 {
         *ptr = 0;
@@ -6,6 +8,7 @@ fn ptr_wrap_add(ptr: &mut usize) {
     }
 }
 
+#[inline]
 fn ptr_wrap_sub(ptr: &mut usize) {
     if *ptr == 0 {
         *ptr = TAPE_SIZE - 1;


### PR DESCRIPTION
I moved the prefaces into their own files with the `include_str!` macro.  I also added the `#[inline]` attribute to the `ptr_wrap_sub` and `ptr_wrap_add` functions in that source code to aid some optimizations.  Hopefully I didn't mess up the indentation of the resultant source code, but perhaps you should be using `libsyntax` for the codegen and/or `rustfmt` for that if you care about it all that much.